### PR TITLE
feat: relax the constraints to detect RBS linkers

### DIFF
--- a/dnabot/dnabot_app.py
+++ b/dnabot/dnabot_app.py
@@ -150,13 +150,12 @@ def generate_constructs_list(path):
         """
 
         def interogate_linker(linker):
-            """Interogates linker to determine if the suffix linker is a UTR
+            """Interrogates linker to determine if the suffix linker is a UTR
             linker.
 
             """
-            if len(linker) >= 4:
-                if linker[:3] == 'UTR':
-                    return linker[:4] + '-S'
+            if linker.startswith('U'):
+                return linker.split('-')[0] + '-S'
             else:
                 return linker + "-S"
 


### PR DESCRIPTION
Hello,

Thanks for the great job. Here a patch to relax a bit the constraints for detecting UTR/RBS linkers. This changes make the code compliant the "raw" ID used in the BioLegio plate (eg `U1-RBS1`, U1-RBS2`, ...) while still working with the IDs initially expected (eg `UTR1-RBS1`, `UTR1-RBS2`, ...).

Best wishes,
Thomas